### PR TITLE
Migration to .netstandard2.0

### DIFF
--- a/Solita.Slack.Notifier.Tests/Properties/AssemblyInfo.cs
+++ b/Solita.Slack.Notifier.Tests/Properties/AssemblyInfo.cs
@@ -1,16 +1,6 @@
 ﻿using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-[assembly: AssemblyTitle("Solita.Slack.Notifier.Tests")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Solita")]
-[assembly: AssemblyProduct("Solita.Slack.Notifier.Tests")]
-[assembly: AssemblyCopyright("Copyright © Solita 2016")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -21,16 +11,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("fa354ee2-4ac8-4c7f-994e-4b741e106d86")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Solita.Slack.Notifier.Tests/Solita.Slack.Notifier.Tests.csproj
+++ b/Solita.Slack.Notifier.Tests/Solita.Slack.Notifier.Tests.csproj
@@ -15,6 +15,8 @@
     <Otherwise />
   </Choose>
   <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
   </ItemGroup>
   <ItemGroup>

--- a/Solita.Slack.Notifier.Tests/Solita.Slack.Notifier.Tests.csproj
+++ b/Solita.Slack.Notifier.Tests/Solita.Slack.Notifier.Tests.csproj
@@ -12,12 +12,11 @@
   </PropertyGroup>
   <Choose>
     <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'" />
-    <Otherwise>
-      <ItemGroup>
-        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
-      </ItemGroup>
-    </Otherwise>
+    <Otherwise />
   </Choose>
+  <ItemGroup>
+    <PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
+  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Solita.Slack.Notifier\Solita.Slack.Notifier.csproj" />
   </ItemGroup>

--- a/Solita.Slack.Notifier.Tests/Solita.Slack.Notifier.Tests.csproj
+++ b/Solita.Slack.Notifier.Tests/Solita.Slack.Notifier.Tests.csproj
@@ -1,48 +1,17 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{FA354EE2-4AC8-4C7F-994E-4B741E106D86}</ProjectGuid>
+    <TargetFramework>net8.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Solita.Slack.Notifier.Tests</RootNamespace>
-    <AssemblyName>Solita.Slack.Notifier.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
-    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
-    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
-    <IsCodedUITest>False</IsCodedUITest>
-    <TestProjectType>UnitTest</TestProjectType>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <AssemblyTitle>Solita.Slack.Notifier.Tests</AssemblyTitle>
+    <Company>Solita</Company>
+    <Product>Solita.Slack.Notifier.Tests</Product>
+    <Copyright>Copyright © Solita 2016</Copyright>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+    <FileVersion>1.0.0.0</FileVersion>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="System" />
-  </ItemGroup>
   <Choose>
-    <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
-      <ItemGroup>
-        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
-      </ItemGroup>
-    </When>
+    <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'" />
     <Otherwise>
       <ItemGroup>
         <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
@@ -50,14 +19,7 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
-    <Compile Include="Tests.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\Solita.Slack.Notifier\Solita.Slack.Notifier.csproj">
-      <Project>{0C97ABE7-627A-4088-8AFF-839F1B938BF0}</Project>
-      <Name>Solita.Slack.Notifier</Name>
-    </ProjectReference>
+    <ProjectReference Include="..\Solita.Slack.Notifier\Solita.Slack.Notifier.csproj" />
   </ItemGroup>
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
@@ -77,13 +39,4 @@
       </ItemGroup>
     </When>
   </Choose>
-  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
 </Project>

--- a/Solita.Slack.Notifier.Tests/Tests.cs
+++ b/Solita.Slack.Notifier.Tests/Tests.cs
@@ -6,7 +6,7 @@ namespace Solita.Slack.Notifier.Tests
     [TestClass]
     public class Tests
     {
-        private const string Endpoint = "https://hooks.slack.com/services/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";
+        private const string Endpoint = "https://hooks.slack.com/services/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";
         private readonly string[] TestMessages = {
             "ASP.NET shutting down due to CodeDirChangeOrDirectoryRename",
 

--- a/Solita.Slack.Notifier.sln
+++ b/Solita.Slack.Notifier.sln
@@ -1,9 +1,9 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.29503.13
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Solita.Slack.Notifier", "Solita.Slack.Notifier\Solita.Slack.Notifier.csproj", "{0C97ABE7-627A-4088-8AFF-839F1B938BF0}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Solita.Slack.Notifier", "Solita.Slack.Notifier\Solita.Slack.Notifier.csproj", "{0C97ABE7-627A-4088-8AFF-839F1B938BF0}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Solita.Slack.Notifier.Tests", "Solita.Slack.Notifier.Tests\Solita.Slack.Notifier.Tests.csproj", "{FA354EE2-4AC8-4C7F-994E-4B741E106D86}"
 EndProject

--- a/Solita.Slack.Notifier.sln
+++ b/Solita.Slack.Notifier.sln
@@ -5,7 +5,7 @@ VisualStudioVersion = 16.0.29503.13
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Solita.Slack.Notifier", "Solita.Slack.Notifier\Solita.Slack.Notifier.csproj", "{0C97ABE7-627A-4088-8AFF-839F1B938BF0}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Solita.Slack.Notifier.Tests", "Solita.Slack.Notifier.Tests\Solita.Slack.Notifier.Tests.csproj", "{FA354EE2-4AC8-4C7F-994E-4B741E106D86}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Solita.Slack.Notifier.Tests", "Solita.Slack.Notifier.Tests\Solita.Slack.Notifier.Tests.csproj", "{FA354EE2-4AC8-4C7F-994E-4B741E106D86}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{3DDD3F29-CE15-46CE-B136-73F437B1E9BE}"
 	ProjectSection(SolutionItems) = preProject

--- a/Solita.Slack.Notifier/Properties/AssemblyInfo.cs
+++ b/Solita.Slack.Notifier/Properties/AssemblyInfo.cs
@@ -1,16 +1,6 @@
 ﻿using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-[assembly: AssemblyTitle("Solita.Slack.Notifier")]
-[assembly: AssemblyDescription("Slack Notifier")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Solita")]
-[assembly: AssemblyProduct("Solita.Slack.Notifier")]
-[assembly: AssemblyCopyright("Copyright © Solita 2016")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -21,15 +11,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("0c97abe7-627a-4088-8aff-839f1b938bf0")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]

--- a/Solita.Slack.Notifier/Solita.Slack.Notifier.csproj
+++ b/Solita.Slack.Notifier/Solita.Slack.Notifier.csproj
@@ -1,75 +1,26 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{0C97ABE7-627A-4088-8AFF-839F1B938BF0}</ProjectGuid>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Solita.Slack.Notifier</RootNamespace>
-    <AssemblyName>Solita.Slack.Notifier</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <AssemblyTitle>Solita.Slack.Notifier</AssemblyTitle>
+    <Description>Slack Notifier</Description>
+    <Company>Solita</Company>
+    <Product>Solita.Slack.Notifier</Product>
+    <Copyright>Copyright © Solita 2016</Copyright>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Debug\Solita.Slack.Notifier.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Release\Solita.Slack.Notifier.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="log4net, Version=1.2.13.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
-      <HintPath>..\packages\log4net.2.0.3\lib\net40-full\log4net.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Configuration" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
+    <PackageReference Include="log4net" Version="2.0.17" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="8.0.0" />
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="ISlackNotifier.cs" />
-    <Compile Include="SlackMessage.cs" />
-    <Compile Include="SlackMessageFactory.cs" />
-    <Compile Include="SlackMessageLevel.cs" />
-    <Compile Include="SlackNotifier.cs" />
-    <Compile Include="Log4net\SlackAppender.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="SlackHttpClient.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
-    <None Include="Solita.Slack.Notifier.nuspec" />
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
 </Project>

--- a/Solita.Slack.Notifier/packages.config
+++ b/Solita.Slack.Notifier/packages.config
@@ -1,5 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="log4net" version="2.0.3" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
-</packages>


### PR DESCRIPTION
Migrated the project `Solita.Slack.Notifier` to .Net Standard 2.0
Updated nuget dependencies in `Solita.Slack.Notifier`
Migrated the project `Solita.Slack.Notifier.Tests` to .Net 8
Updated fixed the test URL with a temporary workspace. 